### PR TITLE
Add password hashing and require users to confirm password on registration

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -17,3 +17,7 @@ config :ex_foo, ExFoo.Repo,
   database: "ex_foo_test",
   hostname: "localhost",
   pool: Ecto.Adapters.SQL.Sandbox
+
+config :argon2_elixir,
+  t_cost: 2,
+  m_cost: 12

--- a/lib/ex_foo/authentication/authentication.ex
+++ b/lib/ex_foo/authentication/authentication.ex
@@ -42,7 +42,12 @@ defmodule ExFoo.Authentication do
 
   ## Examples
 
-      iex> create_user(%{field: value})
+      iex> attrs = %{
+      ...>   email: "test@example.com",
+      ...>   password: "validpassword",
+      ...>   password_confirmation: "validpassword"
+      ...> }
+      iex> create_user(attrs)
       {:ok, %User{}}
 
       iex> create_user(%{field: bad_value})
@@ -51,7 +56,7 @@ defmodule ExFoo.Authentication do
   """
   def create_user(attrs \\ %{}) do
     %User{}
-    |> User.changeset(attrs)
+    |> User.register_changeset(attrs)
     |> Repo.insert()
   end
 

--- a/lib/ex_foo/authentication/user.ex
+++ b/lib/ex_foo/authentication/user.ex
@@ -4,10 +4,13 @@ defmodule ExFoo.Authentication.User do
   """
   use Ecto.Schema
   import Ecto.Changeset
+  alias Comeonin.Argon2
   alias ExFoo.Authentication.User
 
   schema "users" do
     field :email, :string
+    field :password, :string, virtual: true
+    field :password_confirmation, :string, virtual: true
     field :encrypted_password, :string
 
     timestamps()
@@ -16,11 +19,27 @@ defmodule ExFoo.Authentication.User do
   @valid_email_format ~r/^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}$/
 
   @doc false
-  def changeset(%User{} = user, attrs) do
+  def changeset(%User{} = user, attrs \\ %{}) do
     user
-    |> cast(attrs, [:email, :encrypted_password])
-    |> validate_required([:email, :encrypted_password])
+    |> cast(attrs, [:email])
+    |> validate_required([:email])
     |> validate_format(:email, @valid_email_format)
     |> unique_constraint(:email)
   end
+
+  @doc false
+  def register_changeset(%User{} = user, attrs \\ %{}) do
+    user
+    |> changeset(attrs)
+    |> cast(attrs, [:password, :password_confirmation])
+    |> validate_required([:password])
+    |> validate_confirmation(:password, message: "does not match password", required: true)
+    |> put_password_hash()
+  end
+
+  @doc false
+  defp put_password_hash(%Ecto.Changeset{valid?: true, changes: %{password: password}} = changeset) do
+    put_change(changeset, :encrypted_password, Argon2.hashpwsalt(password))
+  end
+  defp put_password_hash(changeset), do: changeset
 end

--- a/lib/ex_foo_web/controllers/user_controller.ex
+++ b/lib/ex_foo_web/controllers/user_controller.ex
@@ -54,18 +54,20 @@ defmodule ExFooWeb.UserController do
   end
 
   swagger_path :create do
-    post "/"
+    post "/users"
     summary "Add a new user"
     description "Register a new user to the application"
     parameters do
-      user :body, Schema.ref(:User), "User to be created", required: true
+      email :query, :string, "Email Address of the user to be created", required: true
+      password :query, :string, "Password that will be assigned to the user", required: true, format: "password"
+      password_confirmation :query, :string, "Check to see if password has been written correctly", required: true, format: "password"
     end
     response 201, "Ok", Schema.ref(:User)
     response 422, "Unprocessable Entity", Schema.ref(:Error)
   end
 
-  def create(conn, %{"user" => user_params}) do
-    with {:ok, %User{} = user} <- AuthContext.create_user(user_params) do
+  def create(conn, params) do
+    with {:ok, %User{} = user} <- AuthContext.create_user(params) do
       conn
       |> put_status(:created)
       |> put_resp_header("location", user_path(conn, :show, user))

--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,9 @@ defmodule ExFoo.Mixfile do
       {:excoveralls, "~> 0.8", only: :test},
       {:phoenix_swagger, "~> 0.7.0"},
       {:ex_json_schema, "~> 0.5"},
-      {:ex_machina, "~> 2.1", only: :test}
+      {:ex_machina, "~> 2.1", only: :test},
+      {:comeonin, "~> 4.0"},
+      {:argon2_elixir, "~> 1.2"},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,8 @@
 %{
+  "argon2_elixir": {:hex, :argon2_elixir, "1.2.14", "0fc4bfbc1b7e459954987d3d2f3836befd72d63f3a355e3978f5005dd6e80816", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], [], "hexpm"},
+  "comeonin": {:hex, :comeonin, "4.0.3", "4e257dcb748ed1ca2651b7ba24fdbd1bd24efd12482accf8079141e3fda23a10", [:mix], [{:argon2_elixir, "~> 1.2", [hex: :argon2_elixir, repo: "hexpm", optional: true]}, {:bcrypt_elixir, "~> 0.12.1 or ~> 1.0", [hex: :bcrypt_elixir, repo: "hexpm", optional: true]}, {:pbkdf2_elixir, "~> 0.12", [hex: :pbkdf2_elixir, repo: "hexpm", optional: true]}], "hexpm"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
   "cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], [], "hexpm"},
@@ -8,6 +10,7 @@
   "db_connection": {:hex, :db_connection, "1.1.3", "89b30ca1ef0a3b469b1c779579590688561d586694a3ce8792985d4d7e575a61", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
   "decimal": {:hex, :decimal, "1.4.1", "ad9e501edf7322f122f7fc151cce7c2a0c9ada96f2b0155b8a09a795c2029770", [:mix], [], "hexpm"},
   "ecto": {:hex, :ecto, "2.2.8", "a4463c0928b970f2cee722cd29aaac154e866a15882c5737e0038bbfcf03ec2c", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
+  "elixir_make": {:hex, :elixir_make, "0.4.0", "992f38fabe705bb45821a728f20914c554b276838433349d4f2341f7a687cddf", [:mix], [], "hexpm"},
   "ex_json_schema": {:hex, :ex_json_schema, "0.5.5", "d8d4c3f47b86c9e634e124d518b290dda82a8b94dcc314e45af10042fc369361", [:mix], [], "hexpm"},
   "ex_machina": {:hex, :ex_machina, "2.1.0", "4874dc9c78e7cf2d429f24dc3c4005674d4e4da6a08be961ffccc08fb528e28b", [:mix], [{:ecto, "~> 2.1", [hex: :ecto, repo: "hexpm", optional: true]}], "hexpm"},
   "excoveralls": {:hex, :excoveralls, "0.8.0", "99d2691d3edf8612f128be3f9869c4d44b91c67cec92186ce49470ae7a7404cf", [:mix], [{:exjsx, ">= 3.0.0", [hex: :exjsx, repo: "hexpm", optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},

--- a/priv/static/swagger.json
+++ b/priv/static/swagger.json
@@ -99,7 +99,7 @@
         "description": "Remove a user from the application"
       }
     },
-    "/": {
+    "/users": {
       "post": {
         "tags": [
           "User"
@@ -121,18 +121,34 @@
         },
         "parameters": [
           {
-            "schema": {
-              "$ref": "#/definitions/User"
-            },
+            "type": "string",
             "required": true,
-            "name": "user",
-            "in": "body",
-            "description": "User to be created"
+            "name": "email",
+            "in": "query",
+            "description": "Email Address of the user to be created"
+          },
+          {
+            "type": "string",
+            "required": true,
+            "name": "password",
+            "in": "query",
+            "format": "password",
+            "description": "Password that will be assigned to the user"
+          },
+          {
+            "type": "string",
+            "required": true,
+            "name": "password_confirmation",
+            "in": "query",
+            "format": "password",
+            "description": "Check to see if password has been written correctly"
           }
         ],
         "operationId": "ExFooWeb.UserController.create",
         "description": "Register a new user to the application"
-      },
+      }
+    },
+    "/": {
       "get": {
         "tags": [
           "User"

--- a/test/ex_foo/authentication/authentication_test.exs
+++ b/test/ex_foo/authentication/authentication_test.exs
@@ -7,8 +7,8 @@ defmodule ExFoo.AuthenticationTest do
   describe "users" do
     alias ExFoo.Authentication.User
 
-    @valid_attrs %{email: "test@example.com", encrypted_password: "some encrypted_password"}
-    @update_attrs %{email: "updated@example.com", encrypted_password: "some updated encrypted_password"}
+    @valid_attrs %{email: "test@example.com", password: "validpassword", password_confirmation: "validpassword"}
+    @update_attrs %{email: "updated@example.com"}
     @invalid_attrs %{email: nil, encrypted_password: nil}
 
     test "list_users/0 returns all users" do
@@ -24,7 +24,8 @@ defmodule ExFoo.AuthenticationTest do
     test "create_user/1 with valid data creates a user" do
       assert {:ok, %User{} = user} = Authentication.create_user(@valid_attrs)
       assert user.email == "test@example.com"
-      assert user.encrypted_password == "some encrypted_password"
+      refute user.encrypted_password == nil
+      refute user.encrypted_password == "validpassword"
     end
 
     test "create_user/1 with duplicate email returns error changeset" do
@@ -43,7 +44,6 @@ defmodule ExFoo.AuthenticationTest do
       assert {:ok, user} = Authentication.update_user(user, @update_attrs)
       assert %User{} = user
       assert user.email == "updated@example.com"
-      assert user.encrypted_password == "some updated encrypted_password"
     end
 
     test "update_user/2 with duplicate email returns error changeset" do

--- a/test/ex_foo_web/controllers/user_controller_test.exs
+++ b/test/ex_foo_web/controllers/user_controller_test.exs
@@ -3,9 +3,9 @@ defmodule ExFooWeb.UserControllerTest do
   use PhoenixSwagger.SchemaTest, "priv/static/swagger.json"
   import ExFoo.Factory
 
-  @create_attrs %{email: "test@example.com", encrypted_password: "some encrypted_password"}
-  @update_attrs %{email: "updated@example.com", encrypted_password: "some updated encrypted_password"}
-  @invalid_attrs %{email: nil, encrypted_password: nil}
+  @create_attrs %{email: "test@example.com", password: "validpassword", password_confirmation: "validpassword"}
+  @update_attrs %{email: "updated@example.com"}
+  @invalid_attrs %{email: nil}
 
   setup %{conn: conn} do
     {:ok, conn: put_req_header(conn, "accept", "application/json")}
@@ -42,7 +42,7 @@ defmodule ExFooWeb.UserControllerTest do
   describe "create user" do
     test "renders user when data is valid", %{conn: conn, swagger_schema: schema} do
       data = conn
-        |> post(user_path(conn, :create), user: @create_attrs)
+        |> post(user_path(conn, :create), @create_attrs)
         |> validate_resp_schema(schema, "User")
         |> json_response(201)
 
@@ -53,7 +53,7 @@ defmodule ExFooWeb.UserControllerTest do
     end
 
     test "renders errors when data is invalid", %{conn: conn} do
-      conn = post conn, user_path(conn, :create), user: @invalid_attrs
+      conn = post conn, user_path(conn, :create), @invalid_attrs
       assert json_response(conn, 422)["errors"] != %{}
     end
   end


### PR DESCRIPTION
This PR adds [Comeonin](https://github.com/riverrun/comeonin) to enable password encryption. This PR also improves the way we're creating users by requiring a Password Confirmation parameter when doing `POST /users`.