### PR TITLE
API Versioning and other Swagger improvements

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -23,7 +23,7 @@ config :logger, :console,
   metadata: [:request_id]
 
 config :plug, :mimes, %{
-  "application/vnd.app.v1+json" => [:v1]
+  "application/vnd.exfoo.v1+json" => [:v1]
 }
 
 # Import environment specific config. This must remain at the bottom

--- a/config/config.exs
+++ b/config/config.exs
@@ -22,6 +22,10 @@ config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]
 
+config :plug, :mimes, %{
+  "application/vnd.app.v1+json" => [:v1]
+}
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env}.exs"

--- a/lib/ex_foo_web/api_version.ex
+++ b/lib/ex_foo_web/api_version.ex
@@ -1,0 +1,20 @@
+defmodule ExFooWeb.APIVersion do
+  @versions Application.get_env(:plug, :mimes)
+  import Plug.Conn
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    [accept] = get_req_header(conn, "accept")
+    version = Map.fetch(@versions, accept)
+    _call(conn, version)
+  end
+
+  defp _call(conn, {:ok, [version]}) do
+    assign(conn, :version, version)
+  end
+  defp _call(conn, _) do
+    # If the API client did not specify anything, just assign the latest version
+    assign(conn, :version, :v1)
+  end
+end

--- a/lib/ex_foo_web/controllers/user_controller.ex
+++ b/lib/ex_foo_web/controllers/user_controller.ex
@@ -42,7 +42,7 @@ defmodule ExFooWeb.UserController do
   end
 
   swagger_path :index do
-    get "/"
+    get "/users"
     summary "List all users"
     description "List all users registered in the application"
     response 200, "Ok", Schema.ref(:Users)
@@ -76,7 +76,7 @@ defmodule ExFooWeb.UserController do
   end
 
   swagger_path :show do
-    get "/{id}"
+    get "/users/{userId}"
     summary "Retrieve a user"
     description "Retrieve a user registered in the application"
     parameters do
@@ -92,12 +92,12 @@ defmodule ExFooWeb.UserController do
   end
 
   swagger_path :update do
-    patch "/{id}"
+    patch "/users/{userId}"
     summary "Update an existing user"
     description "Update the details of an existing user"
     parameters do
       id :path, :string, "The ID of the user", required: true
-      user :body, Schema.ref(:User), "The user details to be updated"
+      email :query, :string, "The new email address of the user to be updated"
     end
     response 200, "Ok", Schema.ref(:User)
     response 422, "Unprocessable Entity", Schema.ref(:Error)
@@ -112,7 +112,7 @@ defmodule ExFooWeb.UserController do
   end
 
   swagger_path :delete do
-    delete "/{id}"
+    delete "/users/{userId}"
     summary "Delete a user"
     description "Remove a user from the application"
     parameters do

--- a/lib/ex_foo_web/controllers/user_controller.ex
+++ b/lib/ex_foo_web/controllers/user_controller.ex
@@ -48,9 +48,9 @@ defmodule ExFooWeb.UserController do
     response 200, "Ok", Schema.ref(:Users)
   end
 
-  def index(conn, _params) do
+  def index(%{assigns: %{version: :v1}} = conn, _params) do
     users = AuthContext.list_users()
-    render(conn, "index.json", users: users)
+    render(conn, "index.v1.json", users: users)
   end
 
   swagger_path :create do
@@ -66,12 +66,12 @@ defmodule ExFooWeb.UserController do
     response 422, "Unprocessable Entity", Schema.ref(:Error)
   end
 
-  def create(conn, params) do
+  def create(%{assigns: %{version: :v1}} = conn, params) do
     with {:ok, %User{} = user} <- AuthContext.create_user(params) do
       conn
       |> put_status(:created)
       |> put_resp_header("location", user_path(conn, :show, user))
-      |> render("show.json", user: user)
+      |> render("show.v1.json", user: user)
     end
   end
 
@@ -86,9 +86,9 @@ defmodule ExFooWeb.UserController do
     response 404, "Not Found", Schema.ref(:Error)
   end
 
-  def show(conn, %{"id" => id}) do
+  def show(%{assigns: %{version: :v1}} = conn, %{"id" => id}) do
     user = AuthContext.get_user(id)
-    render(conn, "show.json", user: user)
+    render(conn, "show.v1.json", user: user)
   end
 
   swagger_path :update do
@@ -103,11 +103,11 @@ defmodule ExFooWeb.UserController do
     response 422, "Unprocessable Entity", Schema.ref(:Error)
   end
 
-  def update(conn, %{"id" => id, "user" => user_params}) do
+  def update(%{assigns: %{version: :v1}} = conn, %{"id" => id, "user" => user_params}) do
     user = AuthContext.get_user(id)
 
     with {:ok, %User{} = user} <- AuthContext.update_user(user, user_params) do
-      render(conn, "show.json", user: user)
+      render(conn, "show.v1.json", user: user)
     end
   end
 
@@ -122,7 +122,7 @@ defmodule ExFooWeb.UserController do
     response 404, "Not Found"
   end
 
-  def delete(conn, %{"id" => id}) do
+  def delete(%{assigns: %{version: :v1}} = conn, %{"id" => id}) do
     user = AuthContext.get_user(id)
     with {:ok, %User{}} <- AuthContext.delete_user(user) do
       send_resp(conn, :no_content, "")

--- a/lib/ex_foo_web/router.ex
+++ b/lib/ex_foo_web/router.ex
@@ -1,8 +1,10 @@
 defmodule ExFooWeb.Router do
   use ExFooWeb, :router
+  alias ExFooWeb.APIVersion
 
   pipeline :api do
-    plug :accepts, ["json"]
+    plug :accepts, ["json", :v1]
+    plug APIVersion
   end
 
   scope "/api", ExFooWeb do

--- a/lib/ex_foo_web/views/user_view.ex
+++ b/lib/ex_foo_web/views/user_view.ex
@@ -2,15 +2,15 @@ defmodule ExFooWeb.UserView do
   use ExFooWeb, :view
   alias ExFooWeb.UserView
 
-  def render("index.json", %{users: users}) do
-    render_many(users, UserView, "user.json")
+  def render("index.v1.json", %{users: users}) do
+    render_many(users, UserView, "user.v1.json")
   end
 
-  def render("show.json", %{user: user}) do
-    render_one(user, UserView, "user.json")
+  def render("show.v1.json", %{user: user}) do
+    render_one(user, UserView, "user.v1.json")
   end
 
-  def render("user.json", %{user: user}) do
+  def render("user.v1.json", %{user: user}) do
     %{
       id: "#{user.id}",
       email: user.email,

--- a/priv/static/swagger.json
+++ b/priv/static/swagger.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "paths": {
-    "/{id}": {
+    "/users/{userId}": {
       "patch": {
         "tags": [
           "User"
@@ -30,13 +30,11 @@
             "description": "The ID of the user"
           },
           {
-            "schema": {
-              "$ref": "#/definitions/User"
-            },
+            "type": "string",
             "required": false,
-            "name": "user",
-            "in": "body",
-            "description": "The user details to be updated"
+            "name": "email",
+            "in": "query",
+            "description": "The new email address of the user to be updated"
           }
         ],
         "operationId": "ExFooWeb.UserController.update",
@@ -146,9 +144,7 @@
         ],
         "operationId": "ExFooWeb.UserController.create",
         "description": "Register a new user to the application"
-      }
-    },
-    "/": {
+      },
       "get": {
         "tags": [
           "User"


### PR DESCRIPTION
This PR introduces API versioning using the `Accept` header. API clients will need to use the following mime type in their requests:

```
application/vnd.exfoo.v1+json
```

However, if the API client still prefers to use `application/json`, it will default to the latest version which is v1 at the moment.

This PR also improves some Swagger documentation for the User endpoints.