### PR TITLE
Add Authentication through the API

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -26,6 +26,10 @@ config :plug, :mimes, %{
   "application/vnd.exfoo.v1+json" => [:v1]
 }
 
+config :ex_foo, ExFoo.Guardian,
+  issuer: "ex_foo",
+  secret_key: System.get_env("EX_FOO_GUARDIAN_SECRET_KEY")
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -44,3 +44,7 @@ config :ex_foo, ExFoo.Repo,
   database: "ex_foo_dev",
   hostname: "localhost",
   pool_size: 10
+
+config :ex_foo, ExFoo.Guardian,
+  issuer: "ex_foo",
+  secret_key: "QP+8cMNrdZga8shK7618R8bRNH7FTxIlV73LtGurfSYFxTOyrNsvXdQXepCBzx2F"

--- a/config/test.exs
+++ b/config/test.exs
@@ -21,3 +21,7 @@ config :ex_foo, ExFoo.Repo,
 config :argon2_elixir,
   t_cost: 2,
   m_cost: 12
+
+config :ex_foo, ExFoo.Guardian,
+  issuer: "ex_foo",
+  secret_key: "QP+8cMNrdZga8shK7618R8bRNH7FTxIlV73LtGurfSYFxTOyrNsvXdQXepCBzx2F"

--- a/lib/ex_foo/authentication/authentication.ex
+++ b/lib/ex_foo/authentication/authentication.ex
@@ -24,8 +24,6 @@ defmodule ExFoo.Authentication do
   @doc """
   Gets a single user.
 
-  Raises `Ecto.NoResultsError` if the User does not exist.
-
   ## Examples
 
       iex> get_user(123)
@@ -36,6 +34,20 @@ defmodule ExFoo.Authentication do
 
   """
   def get_user(id), do: Repo.get(User, id)
+
+  @doc """
+  Gets a single user using a field other than ID.
+
+  ## Examples
+
+      iex> get_user_by(%{email: "valid@example.com"})
+      %User{}
+
+      iex> get_user_by(%{invalid: "value"})
+      nil
+
+  """
+  def get_user_by(map) when map_size(map) == 1, do: Repo.get_by(User, map)
 
   @doc """
   Creates a user.

--- a/lib/ex_foo/guardian/authentication.ex
+++ b/lib/ex_foo/guardian/authentication.ex
@@ -1,0 +1,25 @@
+defmodule ExFoo.Guardian.Authentication do
+  @moduledoc "Contains helpers that can be used for authentication"
+  alias Comeonin.Argon2
+  alias ExFoo.Authentication.User
+  alias ExFoo.Guardian
+
+  def verify_password(nil, _password), do: nil
+  def verify_password(%User{} = user, password) do
+    if Argon2.checkpw(password, user.encrypted_password) do
+      user
+    else
+      nil
+    end
+  end
+
+  def create_token(nil), do: nil
+  def create_token(user) do
+    case Guardian.encode_and_sign(user) do
+      {:ok, token, _claims} ->
+        token
+      _ ->
+        nil
+    end
+  end
+end

--- a/lib/ex_foo/guardian/guardian.ex
+++ b/lib/ex_foo/guardian/guardian.ex
@@ -1,0 +1,53 @@
+defmodule ExFoo.Guardian do
+  @moduledoc "Module required in order to use Guardian inside the app"
+  use Guardian, otp_app: :ex_foo
+
+  alias ExFoo.Authentication
+  alias ExFoo.Authentication.User
+
+  @doc """
+  Encodes the user resource as the sub claim of the token to be passed to the client.
+
+  ## Examples
+
+      iex> attrs = %{email: "test@example.com", password: "password", password_confirmation: "password"}
+      iex> {:ok, user} = Authentication.create_user(attrs)
+      iex> user = %{user | id: 123}
+      iex> subject_for_token(user, nil)
+      {:ok, "User:123"}
+      iex> invalid_user = %{hello: "world"}
+      iex> subject_for_token(invalid_user, nil)
+      {:error, :unknown_resource}
+  """
+  def subject_for_token(%User{} = user, _claims) do
+    sub = "User:" <> to_string(user.id)
+    {:ok, sub}
+  end
+  def subject_for_token(_, _) do
+    {:error, :unknown_resource}
+  end
+
+  @doc ~S"""
+  Decodes the user resource from the sub claim in the received token for authentication.
+
+  ## Examples
+
+      iex> attrs = %{email: "test@example.com", password: "password", password_confirmation: "password"}
+      iex> {:ok, user} = Authentication.create_user(attrs)
+      iex> resource_from_claims(%{"sub" => "User:#{user.id}"})
+      {:ok, %User{}}
+      iex> resource_from_claims(%{"sub" => "User:999"})
+      {:error, :no_result}
+      iex> resource_from_claims(%{"sub" => "Random:123"})
+      {:error, :invalid_claim}
+  """
+  def resource_from_claims(%{"sub" => "User:" <> id}) do
+    case Authentication.get_user(id) do
+      nil -> {:error, :no_result}
+      resource -> {:ok, resource}
+    end
+  end
+  def resource_from_claims(_claims) do
+    {:error, :invalid_claim}
+  end
+end

--- a/lib/ex_foo_web/api_version.ex
+++ b/lib/ex_foo_web/api_version.ex
@@ -1,4 +1,5 @@
 defmodule ExFooWeb.APIVersion do
+  @moduledoc "Plug module for API versioning"
   @versions Application.get_env(:plug, :mimes)
   import Plug.Conn
 

--- a/lib/ex_foo_web/controllers/token_controller.ex
+++ b/lib/ex_foo_web/controllers/token_controller.ex
@@ -1,0 +1,48 @@
+defmodule ExFooWeb.TokenController do
+  use ExFooWeb, :controller
+  use PhoenixSwagger
+
+  alias ExFoo.Authentication
+  alias ExFoo.Guardian.Authentication, as: GuardianAuth
+
+  action_fallback ExFooWeb.FallbackController
+
+  swagger_path :create do
+    post("/token")
+    summary("Creates an authentication token")
+    description("Creates an auth token that can be used to authorize subsequent requests")
+
+    parameters do
+      email(:query, :string, "Email address of a registered user", required: true)
+      password(
+        :query,
+        :string,
+        "The corresponding password of the registered user",
+        required: true,
+        format: "password"
+      )
+    end
+    response(200, "Ok", %{}, headers: %{
+      "Authorization": %{
+        description: "Contains the token (JWT) that the API client can use to authenticate in subsequent requests",
+        type: :string
+      }
+    })
+    response(401, "Unauthorized", Schema.ref(:Error))
+  end
+
+  def create(%{assigns: %{version: :v1}} = conn, %{"email" => email, "password" => password}) do
+    user = Authentication.get_user_by(%{email: email})
+    token = user
+      |> GuardianAuth.verify_password(password)
+      |> GuardianAuth.create_token()
+
+    if token do
+      conn
+      |> put_resp_header("authorization", "Bearer #{token}")
+      |> send_resp(200, token)
+    else
+      send_resp(conn, 401, "")
+    end
+  end
+end

--- a/lib/ex_foo_web/router.ex
+++ b/lib/ex_foo_web/router.ex
@@ -11,6 +11,7 @@ defmodule ExFooWeb.Router do
     pipe_through :api
 
     resources "/users", UserController, except: [:new, :edit]
+    resources "/token", TokenController, only: [:create]
   end
 
   scope "/swagger" do

--- a/mix.exs
+++ b/mix.exs
@@ -48,6 +48,7 @@ defmodule ExFoo.Mixfile do
       {:ex_machina, "~> 2.1", only: :test},
       {:comeonin, "~> 4.0"},
       {:argon2_elixir, "~> 1.2"},
+      {:guardian, "~> 1.0"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{
   "argon2_elixir": {:hex, :argon2_elixir, "1.2.14", "0fc4bfbc1b7e459954987d3d2f3836befd72d63f3a355e3978f5005dd6e80816", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
+  "base64url": {:hex, :base64url, "0.0.1", "36a90125f5948e3afd7be97662a1504b934dd5dac78451ca6e9abf85a10286be", [:rebar], [], "hexpm"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], [], "hexpm"},
   "comeonin": {:hex, :comeonin, "4.0.3", "4e257dcb748ed1ca2651b7ba24fdbd1bd24efd12482accf8079141e3fda23a10", [:mix], [{:argon2_elixir, "~> 1.2", [hex: :argon2_elixir, repo: "hexpm", optional: true]}, {:bcrypt_elixir, "~> 0.12.1 or ~> 1.0", [hex: :bcrypt_elixir, repo: "hexpm", optional: true]}, {:pbkdf2_elixir, "~> 0.12", [hex: :pbkdf2_elixir, repo: "hexpm", optional: true]}], "hexpm"},
@@ -16,8 +17,10 @@
   "excoveralls": {:hex, :excoveralls, "0.8.0", "99d2691d3edf8612f128be3f9869c4d44b91c67cec92186ce49470ae7a7404cf", [:mix], [{:exjsx, ">= 3.0.0", [hex: :exjsx, repo: "hexpm", optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "exjsx": {:hex, :exjsx, "4.0.0", "60548841e0212df401e38e63c0078ec57b33e7ea49b032c796ccad8cde794b5c", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, repo: "hexpm", optional: false]}], "hexpm"},
   "gettext": {:hex, :gettext, "0.14.0", "1a019a2e51d5ad3d126efe166dcdf6563768e5d06c32a99ad2281a1fa94b4c72", [:mix], [], "hexpm"},
+  "guardian": {:hex, :guardian, "1.0.1", "db0fbaf571c3b874785818b7272eaf5f1ed97a2f9b1f8bc5dc8b0fb8f8f7bb06", [:mix], [{:jose, "~> 1.8", [hex: :jose, repo: "hexpm", optional: false]}, {:phoenix, "~> 1.0 or ~> 1.2 or ~> 1.3", [hex: :phoenix, repo: "hexpm", optional: true]}, {:plug, "~> 1.3.3 or ~> 1.4", [hex: :plug, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}, {:uuid, ">= 1.1.1", [hex: :uuid, repo: "hexpm", optional: false]}], "hexpm"},
   "hackney": {:hex, :hackney, "1.11.0", "4951ee019df102492dabba66a09e305f61919a8a183a7860236c0fde586134b6", [:rebar3], [{:certifi, "2.0.0", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "5.1.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "5.1.0", "d72b4effeb324ad5da3cab1767cb16b17939004e789d8c0ad5b70f3cea20c89a", [:rebar3], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
+  "jose": {:hex, :jose, "1.8.4", "7946d1e5c03a76ac9ef42a6e6a20001d35987afd68c2107bcd8f01a84e75aa73", [:mix, :rebar3], [{:base64url, "~> 0.0.1", [hex: :base64url, repo: "hexpm", optional: false]}], "hexpm"},
   "jsx": {:hex, :jsx, "2.8.3", "a05252d381885240744d955fbe3cf810504eb2567164824e19303ea59eef62cf", [:mix, :rebar3], [], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [:mix], [], "hexpm"},
@@ -33,4 +36,5 @@
   "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
+  "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm"},
 }

--- a/priv/static/swagger.json
+++ b/priv/static/swagger.json
@@ -162,6 +162,51 @@
         "operationId": "ExFooWeb.UserController.index",
         "description": "List all users registered in the platform"
       }
+    },
+    "/token": {
+      "post": {
+        "tags": [
+          "Token"
+        ],
+        "summary": "Creates an authentication token",
+        "responses": {
+          "401": {
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "description": "Unauthorized"
+          },
+          "200": {
+            "schema": {},
+            "headers": {
+              "Authorization": {
+                "type": "string",
+                "description": "Contains the token (JWT) that the API client can use to authenticate in subsequent requests"
+              }
+            },
+            "description": "Ok"
+          }
+        },
+        "parameters": [
+          {
+            "type": "string",
+            "required": true,
+            "name": "email",
+            "in": "query",
+            "description": "Email address of a registered user"
+          },
+          {
+            "type": "string",
+            "required": true,
+            "name": "password",
+            "in": "query",
+            "format": "password",
+            "description": "The corresponding password of the registered user"
+          }
+        ],
+        "operationId": "ExFooWeb.TokenController.create",
+        "description": "Creates an auth token that can be used to authorize subsequent requests"
+      }
     }
   },
   "info": {

--- a/test/ex_foo/guardian/guardian_test.exs
+++ b/test/ex_foo/guardian/guardian_test.exs
@@ -1,0 +1,34 @@
+defmodule ExFoo.GuardianTest do
+  use ExFoo.DataCase
+  import ExFoo.Factory
+
+  alias ExFoo.Guardian
+
+  setup do
+    {:ok, user: insert(:user, id: 111)}
+  end
+
+  describe "#subject_for_token" do
+    test "with valid user object returns {:ok, 'User:ID'}", %{user: user} do
+      assert Guardian.subject_for_token(user, nil) == {:ok, "User:111"}
+    end
+
+    test "with invalid user object returns {:error, :unknown_resource}" do
+      assert Guardian.subject_for_token(%{hello: "world"}, nil) == {:error, :unknown_resource}
+    end
+  end
+
+  describe "#resource_from_claims" do
+    test "with valid User sub in token returns {:ok, %User{}}", %{user: user} do
+      assert Guardian.resource_from_claims(%{"sub" => "User:111"}) == {:ok, user}
+    end
+
+    test "with non-existent User sub in token returns {:error, :no_result}" do
+      assert Guardian.resource_from_claims(%{"sub" => "User:123"}) == {:error, :no_result}
+    end
+
+    test "with invalid sub in token returns {:error, :invalid_claim}" do
+      assert Guardian.resource_from_claims(%{"sub" => "Test:123"}) == {:error, :invalid_claim}
+    end
+  end
+end

--- a/test/ex_foo_web/controllers/token_controller_test.exs
+++ b/test/ex_foo_web/controllers/token_controller_test.exs
@@ -1,0 +1,43 @@
+defmodule ExFooWeb.TokenControllerTest do
+  use ExFooWeb.ConnCase
+  import ExFoo.Factory
+  alias Comeonin.Argon2
+
+  @valid_sign_in %{
+    email: "test@example.com",
+    password: "validpassword",
+  }
+
+  @invalid_sign_in %{
+    email: "invalid@example.com",
+    password: "invalidpassword",
+  }
+
+  setup %{conn: conn} do
+    insert(
+      :user,
+      email: "test@example.com",
+      encrypted_password: Argon2.hashpwsalt("validpassword")
+    )
+
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  describe "create" do
+    test "with valid credentials returns authorization header", %{conn: conn} do
+      data = post(conn, token_path(conn, :create), @valid_sign_in)
+      headers = Enum.into(data.resp_headers, %{})
+
+      assert data.status == 200
+      assert headers["authorization"] =~ "Bearer"
+    end
+
+    test "with invalid credentials returns 401 response", %{conn: conn} do
+      data = post(conn, token_path(conn, :create), @invalid_sign_in)
+      headers = Enum.into(data.resp_headers, %{})
+
+      assert data.status == 401
+      assert headers["authorization"] == nil
+    end
+  end
+end


### PR DESCRIPTION
This PR closes #5 and adds [Guardian](https://github.com/ueberauth/guardian) to support JWT authentication. This PR also adds a new endpoint (`POST /token`) for creating new JWT for future authenticated requests.