### PR TITLE
Improve API response objects

### DIFF
--- a/lib/ex_foo_web/controllers/fallback_controller.ex
+++ b/lib/ex_foo_web/controllers/fallback_controller.ex
@@ -12,12 +12,6 @@ defmodule ExFooWeb.FallbackController do
     |> render(ExFooWeb.ChangesetView, "error.json", changeset: changeset)
   end
 
-  def call(conn, {:error, :not_found}) do
-    conn
-    |> put_status(404)
-    |> render(ExFooWeb.ErrorView, "404.json")
-  end
-
   def call(conn, nil) do
     conn
     |> put_status(404)

--- a/lib/ex_foo_web/controllers/fallback_controller.ex
+++ b/lib/ex_foo_web/controllers/fallback_controller.ex
@@ -14,7 +14,13 @@ defmodule ExFooWeb.FallbackController do
 
   def call(conn, {:error, :not_found}) do
     conn
-    |> put_status(:not_found)
-    |> render(ExFooWeb.ErrorView, :"404")
+    |> put_status(404)
+    |> render(ExFooWeb.ErrorView, "404.json")
+  end
+
+  def call(conn, nil) do
+    conn
+    |> put_status(404)
+    |> render(ExFooWeb.ErrorView, "404.json")
   end
 end

--- a/lib/ex_foo_web/controllers/fallback_controller.ex
+++ b/lib/ex_foo_web/controllers/fallback_controller.ex
@@ -8,7 +8,7 @@ defmodule ExFooWeb.FallbackController do
 
   def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
     conn
-    |> put_status(:unprocessable_entity)
+    |> put_status(422)
     |> render(ExFooWeb.ChangesetView, "error.json", changeset: changeset)
   end
 

--- a/lib/ex_foo_web/controllers/user_controller.ex
+++ b/lib/ex_foo_web/controllers/user_controller.ex
@@ -41,7 +41,8 @@ defmodule ExFooWeb.UserController do
           description("Error responses from the API")
 
           properties do
-            error(:string, "The message of the error raised", required: true)
+            code(:string, "The status code of the error", required: true)
+            message(:string, "The detail of the error raised", required: true)
           end
         end
     }
@@ -111,8 +112,9 @@ defmodule ExFooWeb.UserController do
   end
 
   def show(%{assigns: %{version: :v1}} = conn, %{"id" => id}) do
-    user = AuthContext.get_user(id)
-    render(conn, "show.v1.json", user: user)
+    with %User{} = user <- AuthContext.get_user(id) do
+      render(conn, "show.v1.json", user: user)
+    end
   end
 
   swagger_path :update do

--- a/lib/ex_foo_web/controllers/user_controller.ex
+++ b/lib/ex_foo_web/controllers/user_controller.ex
@@ -139,10 +139,10 @@ defmodule ExFooWeb.UserController do
     response(422, "Unprocessable Entity", Schema.ref(:Error))
   end
 
-  def update(%{assigns: %{version: :v1}} = conn, %{"id" => id, "user" => user_params}) do
+  def update(%{assigns: %{version: :v1}} = conn, %{"id" => id} = params) do
     user = AuthContext.get_user(id)
 
-    with {:ok, %User{} = user} <- AuthContext.update_user(user, user_params) do
+    with {:ok, %User{} = user} <- AuthContext.update_user(user, params) do
       render(conn, "show.v1.json", user: user)
     end
   end

--- a/lib/ex_foo_web/controllers/user_controller.ex
+++ b/lib/ex_foo_web/controllers/user_controller.ex
@@ -43,7 +43,15 @@ defmodule ExFooWeb.UserController do
           properties do
             code(:string, "The status code of the error", required: true)
             message(:string, "The detail of the error raised", required: true)
+            field(:string, "Field / Attribute that was affected")
           end
+        end,
+      Errors:
+        swagger_schema do
+          title("Errors")
+          description("A collection of errors")
+          type(:array)
+          items(Schema.ref(:Error))
         end
     }
   end

--- a/lib/ex_foo_web/views/changeset_view.ex
+++ b/lib/ex_foo_web/views/changeset_view.ex
@@ -15,6 +15,12 @@ defmodule ExFooWeb.ChangesetView do
   def render("error.json", %{changeset: changeset}) do
     # When encoded, the changeset returns its errors
     # as a JSON object. So we just pass it forward.
-    %{errors: translate_errors(changeset)}
+    changeset
+    |> translate_errors()
+    |> generate_response()
+  end
+
+  defp generate_response(map) when map_size(map) > 0 do
+    Enum.map(map, fn {k, v} -> %{code: "422", field: "#{k}", message: "#{v}"} end)
   end
 end

--- a/lib/ex_foo_web/views/error_view.ex
+++ b/lib/ex_foo_web/views/error_view.ex
@@ -2,7 +2,7 @@ defmodule ExFooWeb.ErrorView do
   use ExFooWeb, :view
 
   def render("404.json", _assigns) do
-    %{errors: %{detail: "Page not found"}}
+    %{code: "404", message: "Resource not found"}
   end
 
   def render("500.json", _assigns) do

--- a/priv/static/swagger.json
+++ b/priv/static/swagger.json
@@ -258,6 +258,14 @@
       },
       "description": "A user of the platform"
     },
+    "Errors": {
+      "type": "array",
+      "title": "Errors",
+      "items": {
+        "$ref": "#/definitions/Error"
+      },
+      "description": "A collection of errors"
+    },
     "Error": {
       "type": "object",
       "title": "Error",
@@ -269,6 +277,10 @@
         "message": {
           "type": "string",
           "description": "The detail of the error raised"
+        },
+        "field": {
+          "type": "string",
+          "description": "Field / Attribute that was affected"
         },
         "code": {
           "type": "string",

--- a/priv/static/swagger.json
+++ b/priv/static/swagger.json
@@ -262,12 +262,17 @@
       "type": "object",
       "title": "Error",
       "required": [
-        "error"
+        "message",
+        "code"
       ],
       "properties": {
-        "error": {
+        "message": {
           "type": "string",
-          "description": "The message of the error raised"
+          "description": "The detail of the error raised"
+        },
+        "code": {
+          "type": "string",
+          "description": "The status code of the error"
         }
       },
       "description": "Error responses from the API"

--- a/test/ex_foo_web/controllers/user_controller_test.exs
+++ b/test/ex_foo_web/controllers/user_controller_test.exs
@@ -65,6 +65,30 @@ defmodule ExFooWeb.UserControllerTest do
     end
   end
 
+  describe "show user" do
+    test "renders user when id is valid", %{conn: conn, swagger_schema: schema} do
+      user = insert(:user)
+      data =
+        conn
+        |> get(user_path(conn, :show, user))
+        |> validate_resp_schema(schema, "User")
+        |> json_response(200)
+
+      assert data["id"] == "#{user.id}"
+    end
+
+    test "renders error when id is invalid", %{conn: conn, swagger_schema: schema} do
+      data =
+        conn
+        |> get(user_path(conn, :show, 12345))
+        |> validate_resp_schema(schema, "Error")
+        |> json_response(404)
+
+      assert data["code"] == "404"
+      assert data["message"] == "Resource not found"
+    end
+  end
+
   describe "update user" do
     setup [:create_user]
 

--- a/test/ex_foo_web/controllers/user_controller_test.exs
+++ b/test/ex_foo_web/controllers/user_controller_test.exs
@@ -104,7 +104,7 @@ defmodule ExFooWeb.UserControllerTest do
     test "renders user when data is valid", %{conn: conn, user: user, swagger_schema: schema} do
       data =
         conn
-        |> put(user_path(conn, :update, user), user: @update_attrs)
+        |> put(user_path(conn, :update, user), @update_attrs)
         |> validate_resp_schema(schema, "User")
         |> json_response(200)
 
@@ -117,7 +117,7 @@ defmodule ExFooWeb.UserControllerTest do
     test "renders errors when data is invalid", %{conn: conn, user: user, swagger_schema: schema} do
       data =
         conn
-        |> put(user_path(conn, :update, user), user: @invalid_attrs)
+        |> put(user_path(conn, :update, user), @invalid_attrs)
         |> validate_resp_schema(schema, "Errors")
         |> json_response(422)
         |> Enum.at(0)

--- a/test/ex_foo_web/controllers/user_controller_test.exs
+++ b/test/ex_foo_web/controllers/user_controller_test.exs
@@ -59,15 +59,24 @@ defmodule ExFooWeb.UserControllerTest do
       refute data["updated_at"] == nil
     end
 
-    test "renders errors when data is invalid", %{conn: conn} do
-      conn = post(conn, user_path(conn, :create), @invalid_attrs)
-      assert json_response(conn, 422)["errors"] != %{}
+    test "renders errors when data is invalid", %{conn: conn, swagger_schema: schema} do
+      data =
+        conn
+        |> post(user_path(conn, :create), @invalid_attrs)
+        |> validate_resp_schema(schema, "Errors")
+        |> json_response(422)
+        |> Enum.at(0)
+
+      assert data["code"] == "422"
+      assert data["field"] == "email"
+      assert data["message"] == "can't be blank"
     end
   end
 
   describe "show user" do
     test "renders user when id is valid", %{conn: conn, swagger_schema: schema} do
       user = insert(:user)
+
       data =
         conn
         |> get(user_path(conn, :show, user))
@@ -105,9 +114,17 @@ defmodule ExFooWeb.UserControllerTest do
       refute data["updated_at"] == NaiveDateTime.to_iso8601(user.updated_at)
     end
 
-    test "renders errors when data is invalid", %{conn: conn, user: user} do
-      conn = put(conn, user_path(conn, :update, user), user: @invalid_attrs)
-      assert json_response(conn, 422)["errors"] != %{}
+    test "renders errors when data is invalid", %{conn: conn, user: user, swagger_schema: schema} do
+      data =
+        conn
+        |> put(user_path(conn, :update, user), user: @invalid_attrs)
+        |> validate_resp_schema(schema, "Errors")
+        |> json_response(422)
+        |> Enum.at(0)
+
+      assert data["code"] == "422"
+      assert data["field"] == "email"
+      assert data["message"] == "can't be blank"
     end
   end
 

--- a/test/ex_foo_web/views/error_view_test.exs
+++ b/test/ex_foo_web/views/error_view_test.exs
@@ -5,7 +5,10 @@ defmodule ExFooWeb.ErrorViewTest do
   import Phoenix.View
 
   test "renders 404.json" do
-    assert render(ExFooWeb.ErrorView, "404.json", []) == %{errors: %{detail: "Page not found"}}
+    assert render(ExFooWeb.ErrorView, "404.json", []) == %{
+             code: "404",
+             message: "Resource not found"
+           }
   end
 
   test "render 500.json" do


### PR DESCRIPTION
This PR improves some error objects that we are returning to the API clients. Specifically, the Create and Update action for the User resource. Also, the parameters were changed for `User#update` where the params won't need to be enclosed in a `user` object.